### PR TITLE
Use stdout and stderr for logging when in a Docker container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.log
 pid.txt
 node_modules
+Session.vim

--- a/package.json
+++ b/package.json
@@ -1,10 +1,14 @@
 {
   "name": "collector",
   "description": "Sample backend collection engine for splunk javascript client tag",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "private": true,
   "dependencies": {
-    "express": "3.19.2"
+    "express": "3.19.2",
+    "minimist": "1.1.0",
+    "morgan": "1.5.1"
   },
-  "scripts": {"start": "node server.js"}
+  "scripts": {
+    "start": "node server.js --docker"
+  }
 }


### PR DESCRIPTION
- All Splunk events go to stdout
- All other server (error,info,debug) logs go to stderr
- Add minimist to handle new --debug and --docker switches
- Add morgan to create Apache compatible logs, but sent to stderr
