### PR TITLE
Logs are in a subdirectory and Docker defaults to file logging.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
 FROM readytalk/nodejs-runtime
 
+VOLUME /app/logs/
+
 EXPOSE 3000
 EXPOSE 4443

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## Backend Collector for Client-Side Data
 This is a Node.js backend collector for client-side data that is tracked by [sp.js](#appendix-how-to-use-spjs-analytics-javascript-library) Analytics JavaScript library.
-All tracked events are collected in events.log following [logging best practices](http://dev.splunk.com/view/logging-best-practices/SP-CAAADP6) for Splunk log ingestion.
+All tracked events are collected in logs/events.log following [logging best practices](http://dev.splunk.com/view/logging-best-practices/SP-CAAADP6) for Splunk log ingestion.
 
 Refer to [appendix](#appendix-how-to-use-spjs-analytics-javascript-library) below on how to use sp.js simple API for tracking.
 
@@ -25,7 +25,7 @@ Refer to [appendix](#appendix-how-to-use-spjs-analytics-javascript-library) belo
     	Listening to HTTPS on port 4443
 
 That's it!
-After pointing sp.js library to your collector server address using `sp.load(<YOUR_COLLECTOR_URL>)`, watch the tracked events being collected in newly created local file **events.log**
+After pointing sp.js library to your collector server address using `sp.load(<YOUR_COLLECTOR_URL>)`, watch the tracked events being collected in newly created local file **logs/events.log**
 
 ### Additional Resources
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,6 @@
     "morgan": "1.5.1"
   },
   "scripts": {
-    "start": "node server.js --docker"
+    "start": "node server.js"
   }
 }

--- a/server.js
+++ b/server.js
@@ -101,7 +101,7 @@ var createAndLogEvent = function(data, req) {
     console.info(entry);
   } else {
     entry += '\n';
-    fs.appendFile(path.resolve(__dirname, './events.log'), entry, function(err) {
+    fs.appendFile(path.resolve(__dirname, './logs/events.log'), entry, function(err) {
       if (err) {
         console.error(err);
       } else if (argv.debug) {


### PR DESCRIPTION
The previous default was for Docker containers to log to stdout/stderr
but given the ability to setup multi-container deployments we've opted
to log to a file and have the log shipper (Splunk forwarder) read from
the volume.
